### PR TITLE
changes to testing on the IPU

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -3,6 +3,14 @@ import torch.nn as nn
 
 from timm.layers import create_act_layer, set_layer_config
 
+import importlib
+import os
+
+torch_backend = os.environ.get('TORCH_BACKEND')
+if torch_backend is not None:
+    importlib.import_module(torch_backend)
+torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
+
 
 class MLP(nn.Module):
     def __init__(self, act_layer="relu", inplace=True):
@@ -29,6 +37,9 @@ def _run_act_layer_grad(act_type, inplace=True):
         out = m(x)
         l = (out - 0).pow(2).sum()
         return l
+
+    x = x.to(device=torch_device)
+    m.to(device=torch_device)
 
     out_me = _run(x)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,6 +37,7 @@ torch_backend = os.environ.get('TORCH_BACKEND')
 if torch_backend is not None:
     importlib.import_module(torch_backend)
 torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
+timeout = os.environ.get('TIMEOUT', 120)
 
 if hasattr(torch._C, '_jit_set_profiling_executor'):
     # legacy executor is too slow to compile large models for unit tests
@@ -130,7 +131,7 @@ def _get_input_size(model=None, model_name='', target=None):
 
 
 @pytest.mark.base
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(timeout)
 @pytest.mark.parametrize('model_name', list_models(filter=FILTER, exclude_filters=EXCLUDE_FILTERS))
 @pytest.mark.parametrize('batch_size', [1])
 def test_model_forward(model_name, batch_size):
@@ -153,7 +154,7 @@ def test_model_forward(model_name, batch_size):
 
 
 @pytest.mark.base
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(timeout)
 @pytest.mark.parametrize('model_name', list_models(filter=FILTER, exclude_filters=EXCLUDE_FILTERS, name_matches_cfg=True))
 @pytest.mark.parametrize('batch_size', [2])
 def test_model_backward(model_name, batch_size):


### PR DESCRIPTION
Changes to timm library so testing can run on the IPU.
Mainly it's about moving data and models to the IPU.
For model testing both in forward and backwards mode there is a filter so we can run a smaller selection of models.